### PR TITLE
Resolves issue #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ language: php
 sudo: false
 
 php:
-    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
 
 matrix:
     fast_finish: true
     include:
-        - php: 7.0
+        - php: 7.1
           env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "bin": ["bin/rusty"],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
 
         "symfony/process": "^3.0|^4.0",
         "symfony/console": "^3.0|^4.0",
@@ -15,7 +15,7 @@
         "gregwar/rst": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^7.0",
         "mikey179/vfsStream": "^1.6"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log
- Resolves issue #5.
- Dropping `php-7.0` support because this version will be inactive.
- To support active PHP versions, upgrading the minimum PHP and PHPUnit version requirements.