### PR TITLE
Fix deprecated warning for require-dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": { "Rusty\\": "src/" }


### PR DESCRIPTION
# Changed log
- To avoid error message on `composer 2.0` version, using the uppercase package name instead.

The deprecated warning messages on `composer 1.x` version are as follows:

```
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
```