### PR TITLE
Support for Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,17 @@
     "require": {
         "php": "^7.1",
 
-        "symfony/process": "^3.0|^4.0",
-        "symfony/console": "^3.0|^4.0",
-        "symfony/finder": "^3.0|^4.0",
+        "symfony/process": "^3.0|^4.0|^5.0",
+        "symfony/console": "^3.0|^4.0|^5.0",
+        "symfony/finder": "^3.0|^4.0|^5.0",
 
         "nikic/php-parser": "^3.0",
         "league/commonmark": "^0.13",
         "gregwar/rst": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "mikey179/vfsStream": "^1.6"
+        "phpunit/phpunit": "^7.5",
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": { "Rusty\\": "src/" }

--- a/tests/CodeSampleCompilerTest.php
+++ b/tests/CodeSampleCompilerTest.php
@@ -9,7 +9,7 @@ use Rusty\ExecutionContext;
 
 class CodeSampleCompilerTest extends TestCase
 {
-    public function testItTransformsAssertCalls()
+    public function testItTransformsAssertCalls(): void
     {
         $sample = new CodeSample($this->getFileMock(), 42, 'assert(42 === 42);');
         $runtimeNSDir = $this->getRuntimeNSDir();
@@ -25,7 +25,7 @@ CODE;
         $this->assertSame($expectedCode, $compiler->compile($sample, new ExecutionContext(['./target-dir/'])));
     }
 
-    public function testItAllowsBootstrapFilesToBePrepended()
+    public function testItAllowsBootstrapFilesToBePrepended(): void
     {
         $sample = new CodeSample($this->getFileMock(), 42, 'new Foo();');
         $context = new ExecutionContext(['./target-dir/'], ['/some/bootstrap.php', '/other/bootstrap.php']);

--- a/tests/CodeSampleTest.php
+++ b/tests/CodeSampleTest.php
@@ -7,7 +7,7 @@ use Rusty\CodeSample;
 
 class CodeSampleTest extends TestCase
 {
-    public function testItBehavesLikeAContainer()
+    public function testItBehavesLikeAContainer(): void
     {
         /** @var \SplFileInfo $splFileInfoMock */
         $splFileInfoMock = $this->createMock(\SplFileInfo::class);
@@ -25,7 +25,7 @@ class CodeSampleTest extends TestCase
         $this->assertFalse($sample->hasPragma('other directive'));
     }
 
-    public function testItStripsPHPStartingTagFromCode()
+    public function testItStripsPHPStartingTagFromCode(): void
     {
         /** @var \SplFileInfo $splFileInfoMock */
         $splFileInfoMock = $this->createMock(\SplFileInfo::class);

--- a/tests/Extractor/MarkdownTest.php
+++ b/tests/Extractor/MarkdownTest.php
@@ -29,7 +29,7 @@ class MarkdownTest extends TestCase
     /**
      * set up test environmemt
      */
-    public function setUp()
+    public function setUp(): void
     {
         $documents = self::documents();
 
@@ -39,7 +39,7 @@ class MarkdownTest extends TestCase
     /**
      * @dataProvider documentsProvider
      */
-    public function testItExtractsSamplesFromFencedCodeBlocks($documentFile, array $documentData)
+    public function testItExtractsSamplesFromFencedCodeBlocks($documentFile, array $documentData): void
     {
         $file = $this->getFileMock($this->fs->url().'/'.$documentFile);
         $extractor = new Extractor\Markdown();

--- a/tests/Extractor/RstTest.php
+++ b/tests/Extractor/RstTest.php
@@ -28,7 +28,7 @@ class RstTest extends TestCase
     /**
      * set up test environmemt
      */
-    public function setUp()
+    public function setUp(): void
     {
         $documents = self::documents();
 
@@ -38,7 +38,7 @@ class RstTest extends TestCase
     /**
      * @dataProvider documentsProvider
      */
-    public function testItExtractsSamplesFromFencedCodeBlocks($documentFile, array $documentData)
+    public function testItExtractsSamplesFromFencedCodeBlocks($documentFile, array $documentData): void
     {
         $file = $this->getFileMock($this->fs->url().'/'.$documentFile);
         $extractor = new Extractor\Rst();

--- a/tests/Lint/PHPParserLinterTest.php
+++ b/tests/Lint/PHPParserLinterTest.php
@@ -12,7 +12,7 @@ class PHPParserLinterTest extends TestCase
     /**
      * @dataProvider validInputProvider
      */
-    public function testValidCodeThrowNoError(string $code)
+    public function testValidCodeThrowNoError(string $code): void
     {
         /** @var \SplFileInfo $splFileInfoMock */
         $splFileInfoMock = $this->createMock(\SplFileInfo::class);
@@ -32,10 +32,11 @@ class PHPParserLinterTest extends TestCase
 
     /**
      * @dataProvider invalidInputProvider
-     * @expectedException \Rusty\Lint\Exception\SyntaxError
      */
-    public function testInvalidCodeThrowAnError(string $code)
+    public function testInvalidCodeThrowAnError(string $code): void
     {
+        $this->expectException(\Rusty\Lint\Exception\SyntaxError::class);
+
         /** @var \SplFileInfo $splFileInfoMock */
         $splFileInfoMock = $this->createMock(\SplFileInfo::class);
         $sample = new CodeSample($splFileInfoMock, 42, $code);

--- a/tests/PragmaParserTest.php
+++ b/tests/PragmaParserTest.php
@@ -10,7 +10,7 @@ class PragmaParserTest extends TestCase
     /**
      * @dataProvider inputProvider
      */
-    public function testItParsesPragmaDirectives(string $input, array $expectedDirectives)
+    public function testItParsesPragmaDirectives(string $input, array $expectedDirectives): void
     {
         $parser = new PragmaParser();
 

--- a/tests/Reports/BlackholeReporterTest.php
+++ b/tests/Reports/BlackholeReporterTest.php
@@ -7,7 +7,7 @@ use Rusty\Reports;
 
 class BlackholeReporterTest extends TestCase
 {
-    public function testItDoesNothing()
+    public function testItDoesNothing(): void
     {
         $splFile = $this->createMock(\SplFileInfo::class);
         $reporter = new Reports\BlackholeReporter();

--- a/tests/Reports/ConsoleReporterTest.php
+++ b/tests/Reports/ConsoleReporterTest.php
@@ -15,7 +15,7 @@ class ConsoleReporterTest extends TestCase
     /**
      * @dataProvider reportProvider
      */
-    public function testHandledReportsAreDisplayed(Reports\Report $report)
+    public function testHandledReportsAreDisplayed(Reports\Report $report): void
     {
         $output = $this->createMock(OutputInterface::class);
         $formatter = $this->createMock(FormatterHelper::class);


### PR DESCRIPTION
- Add ^5.0 constraint to Symfony packages
- Update tests for PHPUnit 7.5+
  - Add null return types

Related https://github.com/sitemap-php/SitemapGenerator/pull/12

As with above, happy to do what's needed to get this completed :smile_cat: 